### PR TITLE
Update quickstart.md to include docs folder

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,7 +11,7 @@ pip install myst-nb
 You can use the `mystnb-quickstart` CLI to quickly create an example Sphinx + MyST-NB project:
 
 ```bash
-mystnb-quickstart my_project/
+mystnb-quickstart my_project/docs/
 ```
 
 or simply add `myst_nb` to your existing Sphinx configuration:


### PR DESCRIPTION
sphinx projects are often in the "docs folder",
and also the later part of the quick start makes this assumption:
https://myst-nb.readthedocs.io/en/latest/quickstart.html